### PR TITLE
puppet >= 3.8 compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           audit_only => true
         }
 
-* Module dry-run: Do not make any change on *all* the resources provided by the module
-
-        class { 'zabbix_agent':
-          noops => true
-        }
-
 
 ## USAGE - Overrides and Customizations
 * Use custom sources for main config file 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,7 +28,7 @@ class zabbix_agent::config {
   }
 
   # The whole zabbix_agent configuration directory can be recursively overriden
-  if $zabbix_agent::source_dir {
+  if $zabbix_agent::source_dir != '' {
     file { 'zabbix_agent.dir':
       ensure  => directory,
       path    => $zabbix_agent::real_config_dir,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,6 @@ class zabbix_agent::config {
     replace => $zabbix_agent::manage_file_replace,
     notify  => $zabbix_agent::manage_service_autorestart,
     audit   => $zabbix_agent::manage_audit,
-    noop    => $zabbix_agent::noops,
   }
 
   # The whole zabbix_agent configuration directory can be recursively overriden
@@ -39,7 +38,6 @@ class zabbix_agent::config {
       replace => $zabbix_agent::manage_file_replace,
       notify  => $zabbix_agent::manage_service_autorestart,
       audit   => $zabbix_agent::manage_audit,
-      noop    => $zabbix_agent::noops,
     }
   }
 

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -42,7 +42,6 @@ define zabbix_agent::configfile (
     content => template($template),
     replace => $zabbix_agent::manage_file_replace,
     audit   => $zabbix_agent::manage_audit,
-    noop    => $zabbix_agent::noops,
   }
 
 }

--- a/manifests/debug.pp
+++ b/manifests/debug.pp
@@ -11,7 +11,6 @@ class zabbix_agent::debug {
     owner   => 'root',
     group   => 'root',
     content => inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*|.*psk.*|.*key)/ }.to_yaml %>'),
-    noop    => $zabbix_agent::bool_noops,
   }
 
 }

--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -21,7 +21,7 @@ class zabbix_agent::dependencies {
       'Linux': {
         file { "/etc/init.d/${zabbix_agent::service}":
           ensure  => present,
-          mode    => 0755,
+          mode    => '0755',
           owner   => 'root',
           group   => 'root',
           content => template($zabbix_agent::init_script_template),

--- a/manifests/example42.pp
+++ b/manifests/example42.pp
@@ -12,7 +12,6 @@ class zabbix_agent::example42 {
       ensure    => $zabbix_agent::manage_file,
       variables => $classvars,
       helper    => $zabbix_agent::puppi_helper,
-      noop      => $zabbix_agent::noops,
     }
   }
 
@@ -26,7 +25,6 @@ class zabbix_agent::example42 {
         target   => $zabbix_agent::monitor_target,
         tool     => $zabbix_agent::monitor_tool,
         enable   => $zabbix_agent::manage_monitor,
-        noop     => $zabbix_agent::noops,
       }
     }
     if $zabbix_agent::service != '' {
@@ -38,7 +36,6 @@ class zabbix_agent::example42 {
         argument => $zabbix_agent::process_args,
         tool     => $zabbix_agent::monitor_tool,
         enable   => $zabbix_agent::manage_monitor,
-        noop     => $zabbix_agent::noops,
       }
     }
   }
@@ -55,7 +52,6 @@ class zabbix_agent::example42 {
       direction   => 'input',
       tool        => $zabbix_agent::firewall_tool,
       enable      => $zabbix_agent::manage_firewall,
-      noop        => $zabbix_agent::noops,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,11 +164,6 @@
 #   Can be defined also by the (top scope) variables $zabbix_agent_audit_only
 #   and $audit_only
 #
-# [*noops*]
-#   Set noop metaparameter to true for all the resources managed by the module.
-#   Basically you can run a dryrun for this specific module if you set
-#   this to true. Default: undef
-#
 # [*package_source*]
 #   The URL from where to download the Package (http or puppet)
 #
@@ -280,7 +275,6 @@ class zabbix_agent (
   $firewall_dst          = params_lookup( 'firewall_dst' , 'global' ),
   $debug                 = params_lookup( 'debug' , 'global' ),
   $audit_only            = params_lookup( 'audit_only' , 'global' ),
-  $noops                 = params_lookup( 'noops' ),
   $package               = params_lookup( 'package' ),
   $package_source        = params_lookup( 'package_source' ),
   $package_provider      = params_lookup( 'package_provider' ),

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,7 +46,6 @@ class zabbix_agent::install {
         name      => $zabbix_agent::package,
         provider  => $zabbix_agent::real_package_provider,
         source    => $zabbix_agent::real_package_path,
-        noop      => $zabbix_agent::noops,
       }
     }
 
@@ -58,7 +57,6 @@ class zabbix_agent::install {
         url                 => $zabbix_agent::real_install_source,
         destination_dir     => $zabbix_agent::home,
         extracted_dir       => $zabbix_agent::created_dir,
-        noop                => $zabbix_agent::noops,
         require             => File['zabbix_agent_home'],
         postextract_command => "${zabbix_agent::home}/${zabbix_agent::created_dir}/configure --enable-agent && make install",
       }
@@ -70,7 +68,6 @@ class zabbix_agent::install {
         owner   => 'root',
         group   => 'root',
         audit   => $zabbix_agent::manage_audit,
-        noop    => $zabbix_agent::noops,
       }
     }
 
@@ -85,7 +82,6 @@ class zabbix_agent::install {
         user        => $zabbix_agent::process_user,
         auto_deploy => true,
         enable      => true,
-        noop        => $zabbix_agent::noops,
         require     => File['zabbix_agent_home'],
       }
 
@@ -96,7 +92,6 @@ class zabbix_agent::install {
         owner   => $zabbix_agent::config_file_owner,
         group   => $zabbix_agent::config_file_group,
         audit   => $zabbix_agent::manage_audit,
-        noop    => $zabbix_agent::noops,
       }
 
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,6 +116,5 @@ class zabbix_agent::params {
   $puppi_helper = 'standard'
   $debug = false
   $audit_only = false
-  $noops = false
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,6 +116,6 @@ class zabbix_agent::params {
   $puppi_helper = 'standard'
   $debug = false
   $audit_only = false
-  $noops = undef
+  $noops = false
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,7 +19,6 @@ class zabbix_agent::service {
     enable     => $zabbix_agent::manage_service_enable,
     hasstatus  => $zabbix_agent::service_status,
     pattern    => $zabbix_agent::process,
-    noop       => $zabbix_agent::noops,
     provider   => $zabbix_agent::service_provider,
   }
 

--- a/spec/classes/standard42_spec.rb
+++ b/spec/classes/standard42_spec.rb
@@ -100,17 +100,6 @@ describe 'zabbix_agent' do
     it { should contain_firewall('zabbix_agent_tcp_42').with_enable('true') }
   end
 
-  describe 'Test noops mode' do
-    let(:params) { {:install => 'package', :noops => true, :monitor => true , :firewall => true, :port => '42', :protocol => 'tcp'} }
-    it { should contain_package('zabbix_agent').with_noop('true') }
-    it { should contain_service('zabbix_agent').with_noop('true') }
-    it { should contain_file('zabbix_agent.conf').with_noop('true') }
-    it { should contain_monitor__process('zabbix_agent_process').with_noop('true') }
-    it { should contain_monitor__process('zabbix_agent_process').with_noop('true') }
-    it { should contain_monitor__port('zabbix_agent_tcp_42').with_noop('true') }
-    it { should contain_firewall('zabbix_agent_tcp_42').with_noop('true') }
-  end
-
   describe 'Test customizations - template' do
     let(:params) { {:template => "zabbix_agent/spec.erb" , :options => { 'opt_a' => 'value_a' } } }
     it 'should generate a valid template' do


### PR DESCRIPTION
See below for the changes that make the module work with default settings under puppet >= 3.8.
